### PR TITLE
Add JSON to organize data about the transforms in each version tag

### DIFF
--- a/transforms.json
+++ b/transforms.json
@@ -1,0 +1,8965 @@
+{
+  "v2.0.0+2025.04.04": {
+    "systemVersion": {
+      "majorVersion": 2,
+      "minorVersion": 0,
+      "patchVersion": 0,
+      "packageDate": "2025.04.04"
+    },
+    "creationDateTime": "2025-06-09T01:22:18.062882Z",
+    "transforms": [
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScc.a2.v1",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+          "ACEScsc.ACES_to_ACEScc.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScc_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScc/CSC.Academy.ACES_to_ACEScc.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScct.a2.v1",
+        "userName": "ACES2065-1 to ACEScct",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+          "ACEScsc.ACES_to_ACEScct.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScct/CSC.Academy.ACES_to_ACEScct.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScg.a2.v1",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+          "ACEScsc.ACES_to_ACEScg.a1.0.3",
+          "ACEScsc.ACES_to_ACEScg.a1.0.1",
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScg_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScg/CSC.Academy.ACES_to_ACEScg.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACESproxy10i.a2.v1",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACESproxy10i_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACESproxy/CSC.Academy.ACES_to_ACESproxy10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACESproxy12i.a2.v1",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACESproxy12i_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACESproxy/CSC.Academy.ACES_to_ACESproxy12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_BMDFilm_WideGamut_Gen5.a2.v1",
+        "userName": "ACES2605-1 to Blackmagic Film Wide Gamut (Gen 5)",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_BMDFilm_WideGamut_Gen5.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Blackmagic.BMDFilm_WideGamut_Gen5_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/blackmagic_design/CSC.Blackmagic.ACES_to_BMDFilm_WideGamut_Gen5.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScc_to_ACES.a2.v1",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScc.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScc/CSC.Academy.ACEScc_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1",
+        "userName": "ACEScct to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+          "ACEScsc.ACEScct_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScct.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScct/CSC.Academy.ACEScct_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScg_to_ACES.a2.v1",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+          "ACEScsc.ACEScg_to_ACES.a1.0.3",
+          "ACEScsc.ACEScg_to_ACES.a1.0.1",
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScg.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScg/CSC.Academy.ACEScg_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACESproxy10i_to_ACES.a2.v1",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACESproxy10i.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACESproxy/CSC.Academy.ACESproxy10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACESproxy12i_to_ACES.a2.v1",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACESproxy12i.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACESproxy/CSC.Academy.ACESproxy12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ADX10_to_ACES.a2.v1",
+        "userName": "ADX10 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3",
+          "ACEScsc.ADX10_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ADX/CSC.Academy.ADX10_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ADX16_to_ACES.a2.v1",
+        "userName": "ADX16 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3",
+          "ACEScsc.ADX16_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ADX/CSC.Academy.ADX16_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.Unity.a2.v1",
+        "userName": "Unity Transform",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/unity/CSC.Academy.Unity.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Apple.ACES_to_AppleLog_BT2020.a2.v1",
+        "userName": "ACES2065-1 to AppleLog Rec2020",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Apple.AppleLog_BT2020_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/apple/CSC.Apple.ACES_to_AppleLog_BT2020.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Apple.AppleLog_BT2020_to_ACES.a2.v1",
+        "userName": "AppleLog Rec2020 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:IDT.Apple.AppleLog_BT2020.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Apple.ACES_to_AppleLog_BT2020.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/apple/CSC.Apple.AppleLog_BT2020_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC4.a2.v1",
+        "userName": "ACES2065-1 to ARRI LogC4",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC4_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/arri/CSC.Arri.ACES_to_LogCv4.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1",
+        "userName": "ARRI LogC3 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/arri/CSC.Arri.LogCv3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC4_to_ACES.a2.v1",
+        "userName": "ARRI LogC4 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:IDT.ARRI.ARRI-LogC4.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC4.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/arri/CSC.Arri.LogCv4_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Blackmagic.BMDFilm_WideGamut_Gen5_to_ACES.a2.v1",
+        "userName": "Blackmagic Film Wide Gamut (Gen 5) to ACES2605-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.BMDFilm_WideGamut_Gen5_to_ACES.a1.v1",
+          "urn:ampas:aces:transformId:v1.5:IDT.BlackmagicDesign.BMDFilm_WideGamut_Gen5.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_BMDFilm_WideGamut_Gen5.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/blackmagic_design/CSC.Blackmagic.BMDFilm_WideGamut_Gen5_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog2_BT2020.a1.v1",
+        "userName": "ACES2065-1 to Canon Log 2 BT.2020",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog2_BT2020_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.ACES_to_CLog2_BT2020.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog2_CGamut.a1.v1",
+        "userName": "ACES2065-1 to Canon Log 2 Cinema Gamut",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0",
+          "ACEScsc.ACES_to_CLog2_CGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog2_CGamut_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.ACES_to_CLog2_CGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog3_BT2020.a1.v1",
+        "userName": "ACES2065-1 to Canon Log 3 BT.2020",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog3_BT2020_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.ACES_to_CLog3_BT2020.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog3_CGamut.a1.v1",
+        "userName": "ACES2065-1 to Canon Log 3 Cinema Gamut",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0",
+          "ACEScsc.ACES_to_CLog3_CGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog3_CGamut_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.ACES_to_CLog3_CGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog2_BT2020_to_ACES.a1.v1",
+        "userName": "Canon Log 2 BT.2020 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog2_BT2020.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.CLog2_BT2020_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog2_CGamut_to_ACES.a1.v1",
+        "userName": "Canon Log 2 Cinema Gamut to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0",
+          "ACEScsc.CLog2_CGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog2_CGamut.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.CLog2_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog3_BT2020_to_ACES.a1.v1",
+        "userName": "Canon Log 3 BT.2020 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog3_BT2020.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.CLog3_BT2020_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog3_CGamut_to_ACES.a1.v1",
+        "userName": "Canon Log 3 Cinema Gamut to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0",
+          "ACEScsc.CLog3_CGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Canon.ACES_to_CLog3_CGamut.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/canon/CSC.Canon.CLog3_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.DJI.ACES_to_DLog_DGamut.a1.v1",
+        "userName": "ACES2065-1 to DJI DLog DGamut",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.DJI.DLog_DGamut_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/dji/CSC.DJI.ACES_to_DLog_DGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.DJI.DLog_DGamut_to_ACES.a1.v1",
+        "userName": "DJI DLog DGamut to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.DJI.ACES_to_DLog_DGamut.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/dji/CSC.DJI.DLog_DGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Panasonic.ACES_to_VLog_VGamut.a2.v1",
+        "userName": "ACES2065-1 to Panasonic Varicam V-Log V-Gamut",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Panasonic.VLog_VGamut_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/panasonic/CSC.Panasonic.ACES_to_VLog_VGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Panasonic.VLog_VGamut_to_ACES.a2.v1",
+        "userName": "Panasonic Varicam V-Log V-Gamut to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Panasonic.ACES_to_VLog_VGamut.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/panasonic/CSC.Panasonic.VLog_VGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Red.ACES_to_Log3G10_RWG.a2.v1",
+        "userName": "ACES2065-1 to RED Log3G10 REDWideGamutRGB",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0",
+          "ACEScsc.ACES_to_Log3G10_RWG.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Red.Log3G10_RWG_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/red/CSC.Red.ACES_to_Log3G10_RWG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Red.Log3G10_RWG_to_ACES.a2.v1",
+        "userName": "RED Log3G10 REDWideGamutRGB to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0",
+          "ACEScsc.Log3G10_RWG_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Red.ACES_to_Log3G10_RWG.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/red/CSC.Red.Log3G10_RWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_SLog3_SGamut3.a2.v1",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0",
+          "ACEScsc.ACES_to_SLog3_SGamut3.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog3_SGamut3_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.ACES_to_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_SLog3_SGamut3Cine.a2.v1",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3.Cine",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0",
+          "ACEScsc.ACES_to_SLog3_SGamut3Cine.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog3_SGamut3Cine_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.ACES_to_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_Venice_SLog3_SGamut3.a2.v1",
+        "userName": "ACES2065-1 to Sony VENICE S-Log3 S-Gamut3",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.ACES_to_Venice_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_Venice_SLog3_SGamut3Cine.a2.v1",
+        "userName": "ACES2065-1 to Sony VENICE S-Log3 S-Gamut3.Cine",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.ACES_to_Venice_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog1_SGamut_10i_to_ACES.a2.v1",
+        "userName": "Sony S-Log1 S-Gamut 10 bits to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog1_SGamut_10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog1_SGamut_12i_to_ACES.a2.v1",
+        "userName": "Sony S-Log1 S-Gamut 12 bits to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog1_SGamut_12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Daylight_10i_to_ACES.a2.v1",
+        "userName": "Sony S-Log2 S-Gamut2 (Daylight) 10 bits to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog2_SGamut_Daylight_10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Daylight_12i_to_ACES.a2.v1",
+        "userName": "Sony S-Log2 S-Gamut (Daylight) 12 bits to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog2_SGamut_Daylight_12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Tungsten_10i_to_ACES.a2.v1",
+        "userName": "Sony S-Log2 S-Gamut (tungsten) 10 bits to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog2_SGamut_Tungsten_10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Tungsten_12i_to_ACES.a2.v1",
+        "userName": "Sony S-Log2 S-Gamut (tungsten) 12 bits to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog2_SGamut_Tungsten_12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog3_SGamut3_to_ACES.a2.v1",
+        "userName": "Sony S-Log3 S-Gamut3 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0",
+          "ACEScsc.SLog3_SGamut3_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_SLog3_SGamut3.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog3_SGamut3Cine_to_ACES.a2.v1",
+        "userName": "Sony S-Log3 S-Gamut3Cine to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0",
+          "ACEScsc.SLog3_SGamut3Cine_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_SLog3_SGamut3Cine.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3_to_ACES.a2.v1",
+        "userName": "Sony VENICE S-Log3 S-Gamut3 to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_Venice_SLog3_SGamut3.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.Venice_SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.a2.v1",
+        "userName": "Sony VENICE S-Log3 S-Gamut3Cine to ACES2065-1",
+        "transformType": "CSC",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_Venice_SLog3_SGamut3Cine.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/sony/CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvLook.Academy.ReferenceGamutCompress.a2.v1",
+        "userName": "Inverse Reference Gamut Compress",
+        "transformType": "InvLook",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.v1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Look.Academy.ReferenceGamutCompress.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-look/e0e70ecf2ce57d503318dde1fa4aa1bd7287fcdd/reference_gamut_compression/InvLook.Academy.ReferenceGamutCompress.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse Extended DisplayP3 (1000 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/InvOutput.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 1000 nit (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.P3-D60_1000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "userName": "Inverse Rec.2100 HLG (1000 nit P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (1000 nit P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "userName": "Inverse DisplayP3 Gamma 2.2 (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/InvOutput.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse DisplayP3 (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/InvOutput.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_108nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (108 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_108nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.P3-D60_108nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_2000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (2000 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_2000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.P3-D60_2000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (2000 nit P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_300nit_in_XYZ-E_ST2084.a2.v1",
+        "userName": "Inverse DCDM (300 nit P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_300nit_in_XYZ-E_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/dcdm/InvOutput.Academy.P3-D60_300nit_in_XYZ-E_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_4000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (4000 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_4000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.P3-D60_4000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (4000 nit P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "Inverse P3-D65 (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "userName": "Inverse DCDM (P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/dcdm/InvOutput.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_500nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (500 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_500nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.P3-D60_500nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (500 nit P3-D60 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse Extended DisplayP3 (1000 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/InvOutput.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 1000 nit",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.P3-D65_1000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "userName": "Inverse Rec.2100 HLG (1000 nit P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (1000 nit P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "userName": "Inverse DisplayP3 Gamma 2.2",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/InvOutput.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse DisplayP3",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/InvOutput.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_108nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (108 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_108nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.P3-D65_108nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_2000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (2000 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_2000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.P3-D65_2000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (2000 nit P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_300nit_in_XYZ-E_ST2084.a2.v1",
+        "userName": "Inverse DCDM (300 nit P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_300nit_in_XYZ-E_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/dcdm/InvOutput.Academy.P3-D65_300nit_in_XYZ-E_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_4000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (4000 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_4000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.P3-D65_4000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (4000 nit P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "Inverse P3-D65",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "userName": "Inverse DCDM (P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/dcdm/InvOutput.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_500nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (500 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_500nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.P3-D65_500nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (500 nit P3-D65 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (1000 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (2000 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (4000 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (500 nit) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (1000 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (2000 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (4000 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (500 nit)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse DisplayP3 (100 nit Rec.709 Limited) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/InvOutput.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (100 nit Rec.709 Limited) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (100 nit Rec.709 Limited) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/InvOutput.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "userName": "Inverse Rec.709 BT.1886 (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec709/InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "userName": "Inverse sRGB Gamma 2.2 (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/srgb/InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse sRGB Piecewise (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/srgb/InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "Inverse P3-D65 (Rec.709 Limited) (D60 simulation)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/InvOutput.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse DisplayP3 (100 nit Rec.709 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/InvOutput.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "Inverse P3-D65 ST2084 (100 nit Rec.709 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Inverse Rec.2100 ST2084 (100 nit Rec.709 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/InvOutput.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "userName": "Inverse Rec.709 BT.1886",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec709/InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "userName": "Inverse sRGB Gamma 2.2",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/srgb/InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Inverse sRGB Piecewise",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/srgb/InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "Inverse P3-D65 (Rec.709 Limited)",
+        "transformType": "InvOutput",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/InvOutput.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Lib.Academy.ColorSpaces.a2.v1",
+        "userName": "Color Space Conversion",
+        "transformType": "Lib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/2d7af39344725aaa8ac3bf1746693c9a1d6c4792/lib/Lib.Academy.ColorSpaces.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Lib.Academy.DisplayEncoding.a2.v1",
+        "userName": "Display Encoding Functions",
+        "transformType": "Lib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/2d7af39344725aaa8ac3bf1746693c9a1d6c4792/lib/Lib.Academy.DisplayEncoding.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Lib.Academy.OutputTransform.a2.v1",
+        "userName": "Output Transform Functions",
+        "transformType": "Lib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/2d7af39344725aaa8ac3bf1746693c9a1d6c4792/lib/Lib.Academy.OutputTransform.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Lib.Academy.Tonescale.a2.v1",
+        "userName": "Tonescale Functions",
+        "transformType": "Lib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/2d7af39344725aaa8ac3bf1746693c9a1d6c4792/lib/Lib.Academy.Tonescale.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Lib.Academy.Utilities.a2.v1",
+        "userName": "Utilities",
+        "transformType": "Lib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/2d7af39344725aaa8ac3bf1746693c9a1d6c4792/lib/Lib.Academy.Utilities.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Look.Academy.ReferenceGamutCompress.a2.v1",
+        "userName": "Reference Gamut Compress",
+        "transformType": "Look",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.v1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvLook.Academy.ReferenceGamutCompress.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-look/e0e70ecf2ce57d503318dde1fa4aa1bd7287fcdd/reference_gamut_compression/Look.Academy.ReferenceGamutCompress.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Look.Academy.v1_SDR_Tonescale_Match.a2.v1",
+        "userName": "Match SDR Tonescale of ACESv1.x",
+        "transformType": "Look",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-look/e0e70ecf2ce57d503318dde1fa4aa1bd7287fcdd/ACESv1_constrast_match/Look.Academy.Contrast_of_ACESv1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Extended DisplayP3 (1000 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/Output.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 1000 nit (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.P3-D60_1000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "userName": "Rec.2100 HLG (1000 nit P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (1000 nit P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "userName": "DisplayP3 Gamma 2.2 (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/Output.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "DisplayP3 (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/Output.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_108nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (108 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_108nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.P3-D60_108nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_2000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (2000 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_2000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.P3-D60_2000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (2000 nit P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_300nit_in_XYZ-E_ST2084.a2.v1",
+        "userName": "DCDM (300 nit P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_300nit_in_XYZ-E_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/dcdm/Output.Academy.P3-D60_300nit_in_XYZ-E_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_4000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (4000 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_4000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.P3-D60_4000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (4000 nit P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "P3-D65 (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "userName": "DCDM (P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/dcdm/Output.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_500nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (500 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_500nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.P3-D60_500nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (500 nit P3-D60 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "Extended DisplayP3 (1000 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/Output.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 1000 nit",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.P3-D65_1000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "userName": "Rec.2100 HLG (1000 nit P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (1000 nit P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "userName": "DisplayP3 Gamma 2.2",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/Output.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "DisplayP3",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/Output.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_108nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (108 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_108nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.P3-D65_108nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_2000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (2000 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_2000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.P3-D65_2000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (2000 nit P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_300nit_in_XYZ-E_ST2084.a2.v1",
+        "userName": "DCDM (300 nit P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_300nit_in_XYZ-E_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/dcdm/Output.Academy.P3-D65_300nit_in_XYZ-E_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_4000nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (4000 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_4000nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.P3-D65_4000nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (4000 nit P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "P3-D65",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "userName": "DCDM (P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/dcdm/Output.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_500nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (500 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_500nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.P3-D65_500nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (500 nit P3-D65 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (1000 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (2000 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (4000 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (500 nit) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (1000 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (2000 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (4000 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (500 nit)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "DisplayP3 (100 nit Rec.709 Limited) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/displayP3/Output.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (100 nit Rec.709 Limited) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (100 nit Rec.709 Limited) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec2100/Output.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "userName": "Rec.709 BT.1886 (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/rec709/Output.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "userName": "sRGB Gamma 2.2 (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/srgb/Output.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "userName": "sRGB Piecewise (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/srgb/Output.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "P3-D65 (Rec.709 Limited) (D60 simulation)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d60/p3/Output.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "userName": "DisplayP3 (100 nit Rec.709 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/displayP3/Output.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.a2.v1",
+        "userName": "P3-D65 ST2084 (100 nit Rec.709 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "userName": "Rec.2100 ST2084 (100 nit Rec.709 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec2100/Output.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "userName": "Rec.709 BT.1886",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/rec709/Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "userName": "sRGB Gamma 2.2",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/srgb/Output.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "userName": "sRGB Piecewise",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/srgb/Output.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "userName": "P3-D65 (Rec.709 Limited)",
+        "transformType": "Output",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:InvOutput.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-output/aab74723f76728c37345ed01e51ebb24fb1f2f1f/d65/p3/Output.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.ctl"
+      }
+    ]
+  },
+  "v1.3.1": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 3,
+      "patchVersion": 1,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.122428Z",
+    "transforms": [
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScc.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACEScc/ACEScsc.Academy.ACES_to_ACEScc.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+        "userName": "ACES2065-1 to ACEScct",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScct.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACEScct/ACEScsc.Academy.ACES_to_ACEScct.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.3",
+          "ACEScsc.ACES_to_ACEScg.a1.0.1",
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACEScg/ACEScsc.Academy.ACES_to_ACEScg.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACES_to_ACESproxy10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACES_to_ACESproxy12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_BMDFilm_WideGamut_Gen5.a1.v1",
+        "userName": "ACES2605-1 to Blackmagic Film Wide Gamut (Gen 5)",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.BMDFilm_WideGamut_Gen5_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/blackmagic_design/ACEScsc.Academy.ACES_to_Blackmagic_Film_WideGamut_Gen5.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0",
+        "userName": "ACES2065-1 to Canon Log 2 Cinema Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_CLog2_CGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog2_CGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0",
+        "userName": "ACES2065-1 to Canon Log 3 Cinema Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_CLog3_CGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog3_CGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0",
+        "userName": "ACES2065-1 to RED Log3G10 REDWideGamutRGB",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_Log3G10_RWG.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/red/ACEScsc.Academy.ACES_to_Log3G10_RWG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC_EI800_AWG.a1.1.0",
+        "userName": "ACES2065-1 to ARRI LogC EI800 ALEXA Wide Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_LogC_EI800_AWG.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC_EI800_AWG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_SLog3_SGamut3.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3.Cine",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_SLog3_SGamut3Cine.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 VENICE S-Gamut3",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 VENICE S-Gamut3.Cine",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_VLog_VGamut.a1.1.0",
+        "userName": "ACES2065-1 to Panasonic Varicam V-Log V-Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_VLog_VGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/panasonic/ACEScsc.Academy.ACES_to_VLog_VGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACEScc/ACEScsc.Academy.ACEScc_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+        "userName": "ACEScct to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScct_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACEScct/ACEScsc.Academy.ACEScct_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.3",
+          "ACEScsc.ACEScg_to_ACES.a1.0.1",
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACEScg/ACEScsc.Academy.ACEScg_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACESproxy10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACESproxy12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX10_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ADX/ACEScsc.Academy.ADX10_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX16_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/ADX/ACEScsc.Academy.ADX16_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.BMDFilm_WideGamut_Gen5_to_ACES.a1.v1",
+        "userName": "Blackmagic Film Wide Gamut (Gen 5) to ACES2605-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_BMDFilm_WideGamut_Gen5.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/blackmagic_design/ACEScsc.Academy.Blackmagic_Film_WideGamut_Gen5_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0",
+        "userName": "Canon Log 2 Cinema Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.CLog2_CGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/canon/ACEScsc.Academy.CLog2_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0",
+        "userName": "Canon Log 3 Cinema Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.CLog3_CGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/canon/ACEScsc.Academy.CLog3_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0",
+        "userName": "RED Log3G10 REDWideGamutRGB to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.Log3G10_RWG_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/red/ACEScsc.Academy.Log3G10_RWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0",
+        "userName": "ARRI LogC EI800 ALEXA Wide Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.LogC_EI800_AWG_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC_EI800_AWG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/arri/ACEScsc.Academy.LogC_EI800_AWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 S-Gamut3 to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.SLog3_SGamut3_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 S-Gamut3.Cine to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.SLog3_SGamut3Cine_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 VENICE S-Gamut3 to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 VENICE S-Gamut3.Cine to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0",
+        "userName": "Panasonic Varicam V-Log V-Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.VLog_VGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_VLog_VGamut.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/csc/panasonic/ACEScsc.Academy.VLog_VGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.ODT_Common.a1.1.0",
+        "userName": "ACES 1.0 Lib - ODT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.ODT_Common.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.ODT_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.OutputTransforms.a1.1.0",
+        "userName": "ACES 1.0 Lib - Output Transforms",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.OutputTransforms.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.OutputTransforms.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.RRT_Common.a1.1.0",
+        "userName": "ACES 1.0 Lib - RRT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.RRT_Common.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.RRT_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.SSTS.a1.1.0",
+        "userName": "ACES 1.0 Lib - SSTS",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.SSTS.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.SSTS.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Tonescales.a1.0.3",
+        "userName": "ACES 1.0 Lib - Tonescales",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Tonescales.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.Tonescales.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Transform_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - Transform Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Transform_Common.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.Transform_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Utilities_Color.a1.1.0",
+        "userName": "ACES 1.0 Lib - Color Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Utilities_Color.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.Utilities_Color.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Utilities.a1.0.3",
+        "userName": "ACES 1.0 Lib - Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Utilities.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lib/ACESlib.Utilities.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Adjust_Exposure.a1.0.3",
+        "userName": "Adjust Exposure",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Adjust_Exposure.a1.0.3",
+          "ACESlib.Adjust_Exposure.a1.0.1",
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.Adjust_Exposure.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_HLG_1000nits.a1.1.0",
+        "userName": "Dolby PQ to HLG",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.DolbyPQ_to_HLG_1000nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.DolbyPQ_to_HLG_1000nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "userName": "Dolby PQ to Linear",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+          "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+          "ACESlib.ST2048_to_Lin.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.DolbyPQ_to_Lin.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0",
+        "userName": "HLG to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_HLG_1000nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.HLG_to_DolbyPQ_1000nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "userName": "Linear to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+          "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+          "ACESlib.Lin_to_SMPTE2048.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.Lin_to_DolbyPQ.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_Log2_param.a1.0.3",
+        "userName": "Linear to Log2 (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_Log2_param.a1.0.3",
+          "ACESlib.Lin_to_Log2_param.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Log2_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "userName": "Linear to OCIO Shaper (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+          "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.Lin_to_OCIOshaper_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Log2_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Log2_to_Lin_param.a1.0.3",
+          "ACESlib.Log2_to_Lin_param.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_Log2_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.Log2_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+          "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.OCIOshaper_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "userName": "Pre-multiplied Alpha to Straight Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.premultAlpha_to_straightAlpha.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.premultAlpha_to_straightAlpha.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "userName": "Straight Alpha to Pre-multiplied Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.straightAlpha_to_premultAlpha.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.straightAlpha_to_premultAlpha.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Unity.a1.0.3",
+        "userName": "Unity",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Unity.a1.0.3",
+          "ACESlib.Unity.a1.0.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/utilities/ACESutil.Unity.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Apple.AppleLog_BT2020.a1.v1",
+        "userName": "ACES 1.0 Input - AppleLog Rec2020",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/apple/IDT.Apple.AppleLog_BT2020.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI160.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI160.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI200.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI250.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI250.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI320.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI320.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI400.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI400.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI500.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI500.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI640.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI640.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI800.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI800.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.ARRI-LogC4.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI LogC4",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v4/IDT.ARRI.ARRI-LogC4.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.BlackmagicDesign.BMDFilm_WideGamut_Gen5.a1.v1",
+        "userName": "ACES 1.0 Input - Blackmagic Film Wide Gamut (Gen 5)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/blackmagic_design/IDT.BlackmagicDesign.Blackmagic_Film_WideGamut_Gen5_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_BT2020_D55.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog2 BT2020 (Daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_BT2020_D55.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_BT2020_Tng.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog2 BT2020 (Tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_BT2020_Tng.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_CinemaGamut_D55.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_CinemaGamut_D55.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_CinemaGamut_Tng.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_CinemaGamut_Tng.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_BT2020_D55.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog3 BT2020 (Daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_BT2020_D55.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_BT2020_Tng.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog3 BT2020 (Tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_BT2020_Tng.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_CinemaGamut_D55.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_CinemaGamut_D55.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_CinemaGamut_Tng.a1.v2",
+        "userName": "ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_CinemaGamut_Tng.a1.v2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog1_SGamut_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog1_SGamut_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog3_SGamut3.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog3_SGamut3Cine.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.Venice_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3.Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.Venice_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.v1.0",
+        "userName": "ACES 1.3 Inverse Look - Reference Gamut Compress",
+        "transformType": "InvLMT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.v1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - DCDM (P3D65 limited)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM_P3D65limited.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.3",
+          "InvODT.Academy.DCDM.a1.0.1",
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DisplayP3_D60sim_dim.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - DisplayP3 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DisplayP3_D60sim_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/displayp3/InvODT.Academy.DisplayP3_D60sim_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DisplayP3_dim.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - DisplayP3",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DisplayP3_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/displayp3/InvODT.Academy.DisplayP3_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.3",
+          "InvODT.Academy.P3D60_48nits.a1.0.1",
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D65",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/InvODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D65 (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_D60sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/InvODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.3",
+          "InvODT.Academy.P3DCI_48nits.a1.0.1",
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D65 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_D65sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRT.a1.0.3",
+        "userName": "ACES 1.0 - Inverse RRT",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.3",
+          "InvRRT.a1.0.1",
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/rrt/InvRRT.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (108 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+          "InvODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (2000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (4000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_1_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.3",
+          "LMT.Academy.ACES_0_1_1.a1.0.1",
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_2_2.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.3",
+          "LMT.Academy.ACES_0_2_2.a1.0.1",
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_7_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.3",
+          "LMT.Academy.ACES_0_7_1.a1.0.1",
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.BlueLightArtifactFix.a1.1.0",
+        "userName": "ACES 1.0 Look - Blue Light Artifact Fix",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.BlueLightArtifactFix.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lmt/LMT.Academy.BlueLightArtifactFix.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.v1.0",
+        "userName": "ACES 1.3 Look - Reference Gamut Compress",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:LMT.Academy.GamutCompress.a1.3.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.v1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D60.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM (P3D60 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.3",
+          "ODT.Academy.DCDM_P3D60.a1.0.1",
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "userName": "ACES 1.0 Output - DCDM (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D65limited.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.3",
+          "ODT.Academy.DCDM.a1.0.1",
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DisplayP3_D60sim_dim.a1.0.0",
+        "userName": "ACES 1.0 Output - DisplayP3 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DisplayP3_D60sim_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/displayp3/ODT.Academy.DisplayP3_D60sim_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DisplayP3_dim.a1.0.0",
+        "userName": "ACES 1.0 Output - DisplayP3",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DisplayP3_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/displayp3/ODT.Academy.DisplayP3_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.3",
+          "ODT.Academy.P3D60_48nits.a1.0.1",
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/ODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_D60sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/ODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_Rec709limited_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_709limit_48nits.a1.1.0",
+          "ODT.Academy.P3D65_709limit_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/ODT.Academy.P3D65_Rec709limited_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-DCI (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.3",
+          "ODT.Academy.P3DCI_48nits.a1.0.1",
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-DCI (D65 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_D65sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_P3D65limited_100nits_dim.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits.a1.1.0",
+          "ODT.Academy.Rec2020_100nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_P3D65limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits_dim.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits.a1.1.0",
+          "ODT.Academy.Rec2020_Rec709limited_100nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_Rec709limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRT.a1.0.3",
+        "userName": "ACES 1.0 - RRT",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.3",
+          "RRT.a1.0.1",
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/rrt/RRT.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 ST2084 (108 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+          "ODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (2000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (4000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3.1/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      }
+    ]
+  },
+  "v1.3": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 3,
+      "patchVersion": 0,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.175415Z",
+    "transforms": [
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScc.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACEScc/ACEScsc.Academy.ACES_to_ACEScc.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+        "userName": "ACES2065-1 to ACEScct",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScct.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACEScct/ACEScsc.Academy.ACES_to_ACEScct.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.3",
+          "ACEScsc.ACES_to_ACEScg.a1.0.1",
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACEScg/ACEScsc.Academy.ACES_to_ACEScg.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACES_to_ACESproxy10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACES_to_ACESproxy12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0",
+        "userName": "ACES2065-1 to Canon Log 2 Cinema Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_CLog2_CGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog2_CGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0",
+        "userName": "ACES2065-1 to Canon Log 3 Cinema Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_CLog3_CGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog3_CGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0",
+        "userName": "ACES2065-1 to RED Log3G10 REDWideGamutRGB",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_Log3G10_RWG.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/red/ACEScsc.Academy.ACES_to_Log3G10_RWG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC_EI800_AWG.a1.1.0",
+        "userName": "ACES2065-1 to ARRI LogC EI800 ALEXA Wide Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_LogC_EI800_AWG.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC_EI800_AWG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_SLog3_SGamut3.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3.Cine",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_SLog3_SGamut3Cine.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 VENICE S-Gamut3",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0",
+        "userName": "ACES2065-1 to Sony S-Log3 VENICE S-Gamut3.Cine",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_VLog_VGamut.a1.1.0",
+        "userName": "ACES2065-1 to Panasonic Varicam V-Log V-Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_VLog_VGamut.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/panasonic/ACEScsc.Academy.ACES_to_VLog_VGamut.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACEScc/ACEScsc.Academy.ACEScc_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+        "userName": "ACEScct to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScct_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACEScct/ACEScsc.Academy.ACEScct_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.3",
+          "ACEScsc.ACEScg_to_ACES.a1.0.1",
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACEScg/ACEScsc.Academy.ACEScg_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACESproxy10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACESproxy12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX10_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ADX/ACEScsc.Academy.ADX10_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX16_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/ADX/ACEScsc.Academy.ADX16_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0",
+        "userName": "Canon Log 2 Cinema Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.CLog2_CGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/canon/ACEScsc.Academy.CLog2_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0",
+        "userName": "Canon Log 3 Cinema Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.CLog3_CGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/canon/ACEScsc.Academy.CLog3_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0",
+        "userName": "RED Log3G10 REDWideGamutRGB to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.Log3G10_RWG_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/red/ACEScsc.Academy.Log3G10_RWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0",
+        "userName": "ARRI LogC EI800 ALEXA Wide Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.LogC_EI800_AWG_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC_EI800_AWG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/arri/ACEScsc.Academy.LogC_EI800_AWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 S-Gamut3 to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.SLog3_SGamut3_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 S-Gamut3.Cine to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.SLog3_SGamut3Cine_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 VENICE S-Gamut3 to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0",
+        "userName": "Sony S-Log3 VENICE S-Gamut3.Cine to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0",
+        "userName": "Panasonic Varicam V-Log V-Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.VLog_VGamut_to_ACES.a1.v1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_VLog_VGamut.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/csc/panasonic/ACEScsc.Academy.VLog_VGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.ODT_Common.a1.1.0",
+        "userName": "ACES 1.0 Lib - ODT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.ODT_Common.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.ODT_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.OutputTransforms.a1.1.0",
+        "userName": "ACES 1.0 Lib - Output Transforms",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.OutputTransforms.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.OutputTransforms.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.RRT_Common.a1.1.0",
+        "userName": "ACES 1.0 Lib - RRT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.RRT_Common.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.RRT_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.SSTS.a1.1.0",
+        "userName": "ACES 1.0 Lib - SSTS",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.SSTS.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.SSTS.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Tonescales.a1.0.3",
+        "userName": "ACES 1.0 Lib - Tonescales",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Tonescales.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.Tonescales.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Transform_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - Transform Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Transform_Common.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.Transform_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Utilities_Color.a1.1.0",
+        "userName": "ACES 1.0 Lib - Color Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Utilities_Color.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.Utilities_Color.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Utilities.a1.0.3",
+        "userName": "ACES 1.0 Lib - Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Utilities.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lib/ACESlib.Utilities.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Adjust_Exposure.a1.0.3",
+        "userName": "Adjust Exposure",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Adjust_Exposure.a1.0.3",
+          "ACESlib.Adjust_Exposure.a1.0.1",
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.Adjust_Exposure.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_HLG_1000nits.a1.1.0",
+        "userName": "Dolby PQ to HLG",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.DolbyPQ_to_HLG_1000nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.DolbyPQ_to_HLG_1000nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "userName": "Dolby PQ to Linear",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+          "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+          "ACESlib.ST2048_to_Lin.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.DolbyPQ_to_Lin.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0",
+        "userName": "HLG to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_HLG_1000nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.HLG_to_DolbyPQ_1000nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "userName": "Linear to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+          "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+          "ACESlib.Lin_to_SMPTE2048.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.Lin_to_DolbyPQ.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_Log2_param.a1.0.3",
+        "userName": "Linear to Log2 (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_Log2_param.a1.0.3",
+          "ACESlib.Lin_to_Log2_param.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Log2_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "userName": "Linear to OCIO Shaper (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+          "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.Lin_to_OCIOshaper_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Log2_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Log2_to_Lin_param.a1.0.3",
+          "ACESlib.Log2_to_Lin_param.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_Log2_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.Log2_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+          "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.OCIOshaper_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "userName": "Pre-multiplied Alpha to Straight Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.premultAlpha_to_straightAlpha.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.premultAlpha_to_straightAlpha.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "userName": "Straight Alpha to Pre-multiplied Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.straightAlpha_to_premultAlpha.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.straightAlpha_to_premultAlpha.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Unity.a1.0.3",
+        "userName": "Unity",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Unity.a1.0.3",
+          "ACESlib.Unity.a1.0.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/utilities/ACESutil.Unity.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI160.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI160.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI200.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI250.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI250.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI320.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI320.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI400.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI400.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI500.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI500.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI640.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI640.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI800.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI800.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog1_SGamut_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog1_SGamut_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog3_SGamut3.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog3_SGamut3Cine.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.Venice_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3.Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.Venice_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - DCDM (P3D65 limited)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM_P3D65limited.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.3",
+          "InvODT.Academy.DCDM.a1.0.1",
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.3",
+          "InvODT.Academy.P3D60_48nits.a1.0.1",
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D65",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/InvODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D65 (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_D60sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/InvODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.3",
+          "InvODT.Academy.P3DCI_48nits.a1.0.1",
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D65 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_D65sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRT.a1.0.3",
+        "userName": "ACES 1.0 - Inverse RRT",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.3",
+          "InvRRT.a1.0.1",
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/rrt/InvRRT.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (2000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (4000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (108 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+          "InvODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_1_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.3",
+          "LMT.Academy.ACES_0_1_1.a1.0.1",
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_2_2.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.3",
+          "LMT.Academy.ACES_0_2_2.a1.0.1",
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_7_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.3",
+          "LMT.Academy.ACES_0_7_1.a1.0.1",
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.BlueLightArtifactFix.a1.1.0",
+        "userName": "ACES 1.0 Look - Blue Light Artifact Fix",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.BlueLightArtifactFix.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lmt/LMT.Academy.BlueLightArtifactFix.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.GamutCompress.a1.3.0",
+        "userName": "ACES 1.3 Look - Gamut Compress",
+        "transformType": "LMT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/lmt/LMT.Academy.GamutCompress.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D60.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM (P3D60 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.3",
+          "ODT.Academy.DCDM_P3D60.a1.0.1",
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "userName": "ACES 1.0 Output - DCDM (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D65limited.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.3",
+          "ODT.Academy.DCDM.a1.0.1",
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.3",
+          "ODT.Academy.P3D60_48nits.a1.0.1",
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/ODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_D60sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/ODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_Rec709limited_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_709limit_48nits.a1.1.0",
+          "ODT.Academy.P3D65_709limit_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/ODT.Academy.P3D65_Rec709limited_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-DCI (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.3",
+          "ODT.Academy.P3DCI_48nits.a1.0.1",
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-DCI (D65 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_D65sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_P3D65limited_100nits_dim.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits.a1.1.0",
+          "ODT.Academy.Rec2020_100nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_P3D65limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits_dim.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits.a1.1.0",
+          "ODT.Academy.Rec2020_Rec709limited_100nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_Rec709limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRT.a1.0.3",
+        "userName": "ACES 1.0 - RRT",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.3",
+          "RRT.a1.0.1",
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/rrt/RRT.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 ST2084 (108 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+          "ODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (2000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (4000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/p3/RRTODT.Academy.P3D65_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.3/transforms/ctl/outputTransform/rec2020/RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      }
+    ]
+  },
+  "v1.2": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 2,
+      "patchVersion": 0,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.227125Z",
+    "transforms": [
+      {
+        "transformId": "ACEScsc.ACES_to_CLog2_CGamut.a1.v1",
+        "userName": "ACES2065-1 to Canon Log 2 Cinema Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.CLog2_CGamut_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog2_CGamut.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_CLog3_CGamut.a1.v1",
+        "userName": "ACES2065-1 to Canon Log 3 Cinema Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.CLog3_CGamut_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog3_CGamut.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_Log3G10_RWG.a1.v1",
+        "userName": "ACES2065-1 to RED Log3G10 REDWideGamutRGB",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.Log3G10_RWG_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/red/ACEScsc.Academy.ACES_to_Log3G10_RWG.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_LogC_EI800_AWG.a1.v1",
+        "userName": "ACES2065-1 to ARRI LogC EI800 AWG",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.LogC_EI800_AWG_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC_EI800_AWG.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_SLog3_SGamut3.a1.v1",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.SLog3_SGamut3_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES2065-1 to Sony S-Log3 S-Gamut3.Cine",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.SLog3_SGamut3Cine_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_VLog_VGamut.a1.v1",
+        "userName": "ACES2065-1 to Panasonic Varicam V-Log V-Gamut",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.VLog_VGamut_to_ACES.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/panasonic/ACEScsc.Academy.ACES_to_VLog_VGamut.ctl"
+      },
+      {
+        "transformId": "ACEScsc.CLog2_CGamut_to_ACES.a1.v1",
+        "userName": "Canon Log 2 Cinema Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_CLog2_CGamut.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/canon/ACEScsc.Academy.CLog2_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.CLog3_CGamut_to_ACES.a1.v1",
+        "userName": "Canon Log 3 Cinema Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_CLog3_CGamut.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/canon/ACEScsc.Academy.CLog3_CGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.Log3G10_RWG_to_ACES.a1.v1",
+        "userName": "RED Log3G10 REDWideGamutRGB to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_Log3G10_RWG.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/red/ACEScsc.Academy.Log3G10_RWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.LogC_EI800_AWG_to_ACES.a1.v1",
+        "userName": "ARRI LogC EI800 AWG to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_LogC_EI800_AWG.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/arri/ACEScsc.Academy.LogC_EI800_AWG_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.SLog3_SGamut3_to_ACES.a1.v1",
+        "userName": "Sony S-Log3 S-Gamut3 to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_SLog3_SGamut3.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.SLog3_SGamut3Cine_to_ACES.a1.v1",
+        "userName": "Sony S-Log3 S-Gamut3.Cine to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_SLog3_SGamut3Cine.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.VLog_VGamut_to_ACES.a1.v1",
+        "userName": "Panasonic Varicam V-Log V-Gamut to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_VLog_VGamut.a1.v1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/panasonic/ACEScsc.Academy.VLog_VGamut_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScc.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACEScc/ACEScsc.Academy.ACES_to_ACEScc.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+        "userName": "ACES2065-1 to ACEScct",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScct.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACEScct/ACEScsc.Academy.ACES_to_ACEScct.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.3",
+          "ACEScsc.ACES_to_ACEScg.a1.0.1",
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACEScg/ACEScsc.Academy.ACES_to_ACEScg.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACES_to_ACESproxy10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACES_to_ACESproxy12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.3",
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACEScc/ACEScsc.Academy.ACEScc_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3",
+        "userName": "ACEScct to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScct_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACEScct/ACEScsc.Academy.ACEScct_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.3",
+          "ACEScsc.ACEScg_to_ACES.a1.0.1",
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACEScg/ACEScsc.Academy.ACEScg_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy10i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACESproxy10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACESproxy12i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ACESproxy/ACEScsc.Academy.ACESproxy12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX10_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ADX/ACEScsc.Academy.ADX10_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX16_to_ACES.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/csc/ADX/ACEScsc.Academy.ADX16_to_ACES.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.ODT_Common.a1.1.0",
+        "userName": "ACES 1.0 Lib - ODT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.ODT_Common.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.ODT_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.OutputTransforms.a1.1.0",
+        "userName": "ACES 1.0 Lib - Output Transforms",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.OutputTransforms.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.OutputTransforms.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.RRT_Common.a1.1.0",
+        "userName": "ACES 1.0 Lib - RRT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.RRT_Common.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.RRT_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.SSTS.a1.1.0",
+        "userName": "ACES 1.0 Lib - SSTS",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.SSTS.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.SSTS.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Tonescales.a1.0.3",
+        "userName": "ACES 1.0 Lib - Tonescales",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Tonescales.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.Tonescales.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Transform_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - Transform Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Transform_Common.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.Transform_Common.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Utilities_Color.a1.1.0",
+        "userName": "ACES 1.0 Lib - Color Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Utilities_Color.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.Utilities_Color.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESlib.Utilities.a1.0.3",
+        "userName": "ACES 1.0 Lib - Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Utilities.a1.0.3"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lib/ACESlib.Utilities.ctl"
+      },
+      {
+        "transformId": "ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0",
+        "userName": "HLG to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_HLG_1000nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.HLG_to_DolbyPQ_1000nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Adjust_Exposure.a1.0.3",
+        "userName": "Adjust Exposure",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Adjust_Exposure.a1.0.3",
+          "ACESlib.Adjust_Exposure.a1.0.1",
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.Adjust_Exposure.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_HLG_1000nits.a1.1.0",
+        "userName": "Dolby PQ to HLG",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.DolbyPQ_to_HLG_1000nits.a1.1"
+        ],
+        "inverseTransformId": "ACESutil.HLG_to_DolbyPQ_1000nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.DolbyPQ_to_HLG_1000nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "userName": "Dolby PQ to Linear",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+          "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+          "ACESlib.ST2048_to_Lin.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.DolbyPQ_to_Lin.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "userName": "Linear to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+          "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+          "ACESlib.Lin_to_SMPTE2048.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.Lin_to_DolbyPQ.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_Log2_param.a1.0.3",
+        "userName": "Linear to Log2 (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_Log2_param.a1.0.3",
+          "ACESlib.Lin_to_Log2_param.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Log2_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "userName": "Linear to OCIO Shaper (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+          "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.Lin_to_OCIOshaper_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Log2_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Log2_to_Lin_param.a1.0.3",
+          "ACESlib.Log2_to_Lin_param.a1.0.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_Log2_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.Log2_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+          "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.OCIOshaper_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "userName": "Pre-multiplied Alpha to Straight Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.premultAlpha_to_straightAlpha.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.premultAlpha_to_straightAlpha.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "userName": "Straight Alpha to Pre-multiplied Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.straightAlpha_to_premultAlpha.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.straightAlpha_to_premultAlpha.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ACESutil.Unity.a1.0.3",
+        "userName": "Unity",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESutil.Unity.a1.0.3",
+          "ACESlib.Unity.a1.0.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/utilities/ACESutil.Unity.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI160.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI160.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI200.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI250.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI250.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI320.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI320.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI400.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI400.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI500.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI500.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI640.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI640.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI800.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.ARRI.Alexa-v3-logC-EI800.a1.v2"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog1_SGamut_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog1_SGamut_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog3_SGamut3.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [
+          "IDT.Sony.SLog3_SGamut3Cine.a1.v1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.Venice_SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3.Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.Venice_SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - DCDM (P3D65 limited)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM_P3D65limited.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.3",
+          "InvODT.Academy.DCDM.a1.0.1",
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.3",
+          "InvODT.Academy.P3D60_48nits.a1.0.1",
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D65",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/InvODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D65 (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_D60sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/InvODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.3",
+          "InvODT.Academy.P3DCI_48nits.a1.0.1",
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D65 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_D65sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRT.a1.0.3",
+        "userName": "ACES 1.0 - Inverse RRT",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.3",
+          "InvRRT.a1.0.1",
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/rrt/InvRRT.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (2000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (4000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (108 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "InvRRTODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_1_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.3",
+          "LMT.Academy.ACES_0_1_1.a1.0.1",
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_2_2.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.3",
+          "LMT.Academy.ACES_0_2_2.a1.0.1",
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.ACES_0_7_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.3",
+          "LMT.Academy.ACES_0_7_1.a1.0.1",
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:LMT.Academy.BlueLightArtifactFix.a1.1.0",
+        "userName": "ACES 1.0 Look - Blue Light Artifact Fix",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.BlueLightArtifactFix.a1.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/lmt/LMT.Academy.BlueLightArtifactFix.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D60.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM (P3D60 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.3",
+          "ODT.Academy.DCDM_P3D60.a1.0.1",
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "userName": "ACES 1.0 Output - DCDM (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D65limited.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM_P3D65limited.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.3",
+          "ODT.Academy.DCDM.a1.0.1",
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.3",
+          "ODT.Academy.P3D60_48nits.a1.0.1",
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/ODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_709limit_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_709limit_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/ODT.Academy.P3D65_Rec709limited_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_D60sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/ODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-DCI (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.3",
+          "ODT.Academy.P3DCI_48nits.a1.0.1",
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-DCI (D65 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_D65sim_48nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_P3D65limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_Rec709limited_100nits.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_Rec709limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRT.a1.0.3",
+        "userName": "ACES 1.0 - RRT",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.3",
+          "RRT.a1.0.1",
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/rrt/RRT.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.P3D65_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3D65 ST2084 (108 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (2000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.P3D65_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - P3-D65 ST2084 (4000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.P3D65_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "RRTODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1"
+        ],
+        "inverseTransformId": "urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.2/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      }
+    ]
+  },
+  "v1.1": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 1,
+      "patchVersion": 0,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.279157Z",
+    "transforms": [
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScc.a1.0.3",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScc_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACEScc/ACEScsc.ACES_to_ACEScc.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScct.a1.0.3",
+        "userName": "ACES2065-1 to ACEScct",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACEScct_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACEScct/ACEScsc.ACES_to_ACEScct.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScg.a1.0.3",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.1",
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScg_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACEScg/ACEScsc.ACES_to_ACEScg.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACESproxy/ACEScsc.ACES_to_ACESproxy10i.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACESproxy/ACEScsc.ACES_to_ACESproxy12i.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScc_to_ACES.a1.0.3",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScc.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACEScc/ACEScsc.ACEScc_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScct_to_ACES.a1.0.3",
+        "userName": "ACEScct to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScct.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACEScct/ACEScsc.ACEScct_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScg_to_ACES.a1.0.3",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.1",
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScg.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACEScg/ACEScsc.ACEScg_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACESproxy/ACEScsc.ACESproxy10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ACESproxy/ACEScsc.ACESproxy12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX10_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ADX/ACEScsc.ADX10_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX16_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/csc/ADX/ACEScsc.ADX16_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACESlib.ODT_Common.a1.1",
+        "userName": "ACES 1.0 Lib - ODT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.ODT_Common.ctl"
+      },
+      {
+        "transformId": "ACESlib.OutputTransforms.a1.1",
+        "userName": "ACES 1.0 Lib - Output Transforms",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.OutputTransforms.ctl"
+      },
+      {
+        "transformId": "ACESlib.RRT_Common.a1.1",
+        "userName": "ACES 1.0 Lib - RRT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.RRT_Common.ctl"
+      },
+      {
+        "transformId": "ACESlib.SSTS.a1.1",
+        "userName": "ACES 1.0 Lib - SSTS",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.SSTS.ctl"
+      },
+      {
+        "transformId": "ACESlib.Tonescales.a1.0.3",
+        "userName": "ACES 1.0 Lib - Tonescales",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.Tonescales.ctl"
+      },
+      {
+        "transformId": "ACESlib.Transform_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - Transform Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.Transform_Common.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities_Color.a1.1",
+        "userName": "ACES 1.0 Lib - Color Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.Utilities_Color.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities.a1.0.3",
+        "userName": "ACES 1.0 Lib - Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lib/ACESlib.Utilities.ctl"
+      },
+      {
+        "transformId": "ACESutil.Adjust_Exposure.a1.0.3",
+        "userName": "Adjust Exposure",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Adjust_Exposure.a1.0.1",
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.Adjust_Exposure.ctl"
+      },
+      {
+        "transformId": "ACESutil.DolbyPQ_to_HLG_1000nits.a1.1",
+        "userName": "Dolby PQ to HLG",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESutil.HLG_to_DolbyPQ_1000nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.DolbyPQ_to_HLG_1000nits.ctl"
+      },
+      {
+        "transformId": "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "userName": "Dolby PQ to Linear",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+          "ACESlib.ST2048_to_Lin.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.DolbyPQ_to_Lin.ctl"
+      },
+      {
+        "transformId": "ACESutil.HLG_to_DolbyPQ_1000nits.a1.1",
+        "userName": "HLG to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESutil.DolbyPQ_to_HLG_1000nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.HLG_to_DolbyPQ_1000nits.ctl"
+      },
+      {
+        "transformId": "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "userName": "Linear to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+          "ACESlib.Lin_to_SMPTE2048.a1.0.1"
+        ],
+        "inverseTransformId": "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.Lin_to_DolbyPQ.ctl"
+      },
+      {
+        "transformId": "ACESutil.Lin_to_Log2_param.a1.0.3",
+        "userName": "Linear to Log2 (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_Log2_param.a1.0.1"
+        ],
+        "inverseTransformId": "ACESutil.Log2_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "userName": "Linear to OCIO Shaper (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.Lin_to_OCIOshaper_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.Log2_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Log2_to_Lin_param.a1.0.1"
+        ],
+        "inverseTransformId": "ACESutil.Lin_to_Log2_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.Log2_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.OCIOshaper_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "userName": "Pre-multiplied Alpha to Straight Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.premultAlpha_to_straightAlpha.ctl"
+      },
+      {
+        "transformId": "ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "userName": "Straight Alpha to Pre-multiplied Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.straightAlpha_to_premultAlpha.ctl"
+      },
+      {
+        "transformId": "ACESutil.Unity.a1.0.3",
+        "userName": "Unity",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Unity.a1.0.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/utilities/ACESutil.Unity.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI160.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI250.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI320.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI400.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI500.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI640.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI800.a1.v2",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.DCDM_P3D65limited.a1.1",
+        "userName": "ACES 1.0 Inverse Output - DCDM (P3D65 limited)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.DCDM_P3D65limited.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.1",
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.1",
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Inverse Output - P3D65 ST2084 (108 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D65_48nits.a1.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D65",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D65_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/InvODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D65_D60sim_48nits.a1.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D65 (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D65_D60sim_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/InvODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D60 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.1",
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3DCI_D65sim_48nits.a1.1",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI (D65 simulation)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3DCI_D65sim_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/sRGB/InvODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvRRT.a1.0.3",
+        "userName": "ACES 1.0 - Inverse RRT",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.1",
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "RRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/rrt/InvRRT.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_1_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.1",
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_2_2.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.1",
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_7_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.1",
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.BlueLightArtifactFix.a1.1",
+        "userName": "ACES 1.0 Look - Blue Light Artifact Fix",
+        "transformType": "LMT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/lmt/LMT.Academy.BlueLightArtifactFix.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM_P3D60.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM (P3D60 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.1",
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60limited.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM_P3D65limited.a1.1",
+        "userName": "ACES 1.0 Output - DCDM (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.DCDM_P3D65limited.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D65limited.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.1",
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.1",
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Output - P3D65 ST2084 (108 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D65_108nits_7.2nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D65_48nits.a1.1",
+        "userName": "ACES 1.0 Output - P3D65",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D65_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/ODT.Academy.P3D65_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D65_709limit_48nits.a1.1",
+        "userName": "ACES 1.0 Output - P3D65 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D65_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/ODT.Academy.P3D65_Rec709limited_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D65_D60sim_48nits.a1.1",
+        "userName": "ACES 1.0 Output - P3D65 (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D65_D60sim_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/ODT.Academy.P3D65_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-DCI (D60 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.1",
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D60sim_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3DCI_D65sim_48nits.a1.1",
+        "userName": "ACES 1.0 Output - P3-DCI (D65 simulation)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3DCI_D65sim_48nits.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/p3/ODT.Academy.P3DCI_D65sim_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1",
+        "userName": "ACES 1.0 Output - Rec.2020 HLG (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_100nits.a1.1",
+        "userName": "ACES 1.0 Output - Rec.2020 (P3D65 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_P3D65limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (2000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (4000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/outputTransforms/RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_Rec709limited_100nits.a1.1",
+        "userName": "ACES 1.0 Output - Rec.2020 (Rec.709 Limited)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_Rec709limited_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/odt/sRGB/ODT.Academy.sRGB_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "RRT.a1.0.3",
+        "userName": "ACES 1.0 - RRT",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.1",
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "InvRRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.1/transforms/ctl/rrt/RRT.ctl"
+      }
+    ]
+  },
+  "v1.0.3": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 0,
+      "patchVersion": 3,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.324007Z",
+    "transforms": [
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScc.a1.0.3",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScc_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACEScc/ACEScsc.ACES_to_ACEScc.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScct.a1.0.3",
+        "userName": "ACES2065-1 to ACEScct",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACEScct_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACEScct/ACEScsc.ACES_to_ACEScct.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScg.a1.0.3",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.1",
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScg_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACEScg/ACEScsc.ACES_to_ACEScg.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACESproxy/ACEScsc.ACES_to_ACESproxy10i.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACESproxy/ACEScsc.ACES_to_ACESproxy12i.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScc_to_ACES.a1.0.3",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.1",
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScc.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACEScc/ACEScsc.ACEScc_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScct_to_ACES.a1.0.3",
+        "userName": "ACEScct to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScct.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACEScct/ACEScsc.ACEScct_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScg_to_ACES.a1.0.3",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.1",
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScg.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACEScg/ACEScsc.ACEScg_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACESproxy/ACEScsc.ACESproxy10i_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.3",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ACESproxy/ACEScsc.ACESproxy12i_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX10_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ADX/ACEScsc.ADX10_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX16_to_ACES.a1.0.3",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/csc/ADX/ACEScsc.ADX16_to_ACES.ctl"
+      },
+      {
+        "transformId": "ACESlib.ODT_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - ODT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lib/ACESlib.ODT_Common.ctl"
+      },
+      {
+        "transformId": "ACESlib.RRT_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - RRT Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lib/ACESlib.RRT_Common.ctl"
+      },
+      {
+        "transformId": "ACESlib.Tonescales.a1.0.3",
+        "userName": "ACES 1.0 Lib - Tonescales",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lib/ACESlib.Tonescales.ctl"
+      },
+      {
+        "transformId": "ACESlib.Transform_Common.a1.0.3",
+        "userName": "ACES 1.0 Lib - Transform Common",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lib/ACESlib.Transform_Common.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities_Color.a1.0.3",
+        "userName": "ACES 1.0 Lib - Color Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lib/ACESlib.Utilities_Color.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities.a1.0.3",
+        "userName": "ACES 1.0 Lib - Utilities",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lib/ACESlib.Utilities.ctl"
+      },
+      {
+        "transformId": "ACESutil.Adjust_Exposure.a1.0.3",
+        "userName": "Adjust Exposure",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Adjust_Exposure.a1.0.1",
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.Adjust_Exposure.ctl"
+      },
+      {
+        "transformId": "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "userName": "Dolby PQ to Linear",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+          "ACESlib.ST2048_to_Lin.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.DolbyPQ_to_Lin.ctl"
+      },
+      {
+        "transformId": "ACESutil.Lin_to_DolbyPQ.a1.0.3",
+        "userName": "Linear to Dolby PQ",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+          "ACESlib.Lin_to_SMPTE2048.a1.0.1"
+        ],
+        "inverseTransformId": "ACESutil.DolbyPQ_to_Lin.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.Lin_to_DolbyPQ.ctl"
+      },
+      {
+        "transformId": "ACESutil.Lin_to_Log2_param.a1.0.3",
+        "userName": "Linear to Log2 (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_Log2_param.a1.0.1"
+        ],
+        "inverseTransformId": "ACESutil.Log2_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "userName": "Linear to OCIO Shaper (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.Lin_to_OCIOshaper_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.Log2_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Log2_to_Lin_param.a1.0.1"
+        ],
+        "inverseTransformId": "ACESutil.Lin_to_Log2_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.Log2_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.OCIOshaper_to_Lin_param.a1.0.3",
+        "userName": "OCIO Shaper to Linear (Parametric)",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESutil.Lin_to_OCIOshaper_param.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.OCIOshaper_to_Lin_param.ctl"
+      },
+      {
+        "transformId": "ACESutil.premultAlpha_to_straightAlpha.a1.0.3",
+        "userName": "Pre-multiplied Alpha to Straight Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.premultAlpha_to_straightAlpha.ctl"
+      },
+      {
+        "transformId": "ACESutil.straightAlpha_to_premultAlpha.a1.0.3",
+        "userName": "Straight Alpha to Pre-multiplied Alpha",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.straightAlpha_to_premultAlpha.ctl"
+      },
+      {
+        "transformId": "ACESutil.Unity.a1.0.3",
+        "userName": "Unity",
+        "transformType": "ACESutil",
+        "equivalentTransformIds": [
+          "ACESlib.Unity.a1.0.1"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/utilities/ACESutil.Unity.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI160.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI250.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI320.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI400.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI500.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI640.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI800.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog3_SGamut3.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog3_SGamut3Cine.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog3 SGamut3Cine",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog3_SGamut3Cine.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.1",
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.1",
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2084_1000nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2084 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_ST2084_1000nits.a1.0.1",
+          "InvODT.Academy.P3D60_ST2048_1000nits.a1.0.1",
+          "InvODT.Academy.P3D60_PQ_1000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2084_1000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/InvODT.Academy.P3D60_ST2084_1000nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2084_2000nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2084 (2000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_ST2084_2000nits.a1.0.1",
+          "InvODT.Academy.P3D60_ST2048_2000nits.a1.0.1",
+          "InvODT.Academy.P3D60_PQ_2000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2084_2000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/InvODT.Academy.P3D60_ST2084_2000nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2084_4000nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2084 (4000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_ST2084_4000nits.a1.0.1",
+          "InvODT.Academy.P3D60_ST2048_4000nits.a1.0.1",
+          "InvODT.Academy.P3D60_PQ_4000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2084_4000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/InvODT.Academy.P3D60_ST2084_4000nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.1",
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_48nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_ST2084_1000nits.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_ST2084_1000nits.a1.0.2",
+          "InvODT.Academy.Rec2020_ST2048_1000nits.a1.0.1"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec2020_ST2084_1000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/InvODT.Academy.Rec2020_ST2084_1000nits.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "InvRRT.a1.0.3",
+        "userName": "ACES 1.0 - Inverse RRT",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.1",
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "RRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/rrt/InvRRT.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_1_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.1",
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_2_2.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.1",
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_7_1.a1.0.3",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.1",
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM_P3D60.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM (P3 gamut clip)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.1",
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM.a1.0.3",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.1",
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.1",
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2084_1000nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60 ST2084 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_ST2084_1000nits.a1.0.1",
+          "ODT.Academy.P3D60_ST2048_1000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2084_1000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/ODT.Academy.P3D60_ST2084_1000nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2084_2000nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60 ST2084 (2000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_ST2084_2000nits.a1.0.1",
+          "ODT.Academy.P3D60_ST2048_2000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2084_2000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/ODT.Academy.P3D60_ST2084_2000nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2084_4000nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-D60 ST2084 (4000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_ST2084_4000nits.a1.0.1",
+          "ODT.Academy.P3D60_ST2048_4000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2084_4000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/ODT.Academy.P3D60_ST2084_4000nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3DCI_48nits.a1.0.3",
+        "userName": "ACES 1.0 Output - P3-DCI",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.1",
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3DCI_48nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/p3/ODT.Academy.P3DCI_48nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_ST2084_1000nits.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_ST2084_1000nits.a1.0.1",
+          "ODT.Academy.Rec2020_ST2048_1000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec2020_ST2084_1000nits.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/hdr_st2084/ODT.Academy.Rec2020_ST2084_1000nits.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_100nits_dim.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_D60sim_100nits_dim.ctl"
+      },
+      {
+        "transformId": "RRT.a1.0.3",
+        "userName": "ACES 1.0 - RRT",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.1",
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "InvRRT.a1.0.3",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.3/transforms/ctl/rrt/RRT.ctl"
+      }
+    ]
+  },
+  "v1.0.2": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 0,
+      "patchVersion": 2,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.365436Z",
+    "transforms": [
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScc.a1.0.1",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScc.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScc_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACEScc/ACEScsc.ACES_to_ACEScc.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScg.a1.0.1",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScg_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACEScg/ACEScsc.ACES_to_ACEScg.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACESproxy/ACEScsc.ACES_to_ACESproxy10i.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACESproxy/ACEScsc.ACES_to_ACESproxy12i.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScc_to_ACES.a1.0.1",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScc.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACEScc/ACEScsc.ACEScc_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScg_to_ACES.a1.0.1",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScg.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACEScg/ACEScsc.ACEScg_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACESproxy/ACEScsc.ACESproxy10i_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/ACESproxy/ACEScsc.ACESproxy12i_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX10_to_ACES.a1.0.1",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX10_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/unbuild/universal/ACEScsc.ADX10_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX16_to_ACES.a1.0.1",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX16_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/unbuild/universal/ACEScsc.ADX16_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Adjust_Exposure.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Adjust_Exposure.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.ST2048_to_Lin.a1.0.1.ctl"
+        ],
+        "inverseTransformId": "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.DolbyPQ_to_Lin.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Lin_to_DolbyPQ.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Lin_to_SMPTE2048.a1.0.1"
+        ],
+        "inverseTransformId": "ACESlib.DolbyPQ_to_Lin.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Lin_to_DolbyPQ.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Lin_to_Log2_param.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Log2_to_Lin_param.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Lin_to_Log2_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Log2_to_Lin_param.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Lin_to_Log2_param.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Log2_to_Lin_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.ODT_Common.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.ODT_Common.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.RRT_Common.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.RRT_Common.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Tonescales.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Tonescales.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Transform_Common.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Transform_Common.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Unity.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Unity.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities_Color.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Utilities_Color.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/utilities/ACESlib.Utilities.a1.0.1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI160.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI250.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI320.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI400.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI500.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI640.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI800.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.DCDM.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.DCDM.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_48nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2084_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2084 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_ST2048_1000nits.a1.0.1",
+          "InvODT.Academy.P3D60_PQ_1000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2084_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/InvODT.Academy.P3D60_ST2084_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2084_2000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2084 (2000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_ST2048_2000nits.a1.0.1",
+          "InvODT.Academy.P3D60_PQ_2000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2084_2000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/InvODT.Academy.P3D60_ST2084_2000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2084_4000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2084 (4000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_ST2048_4000nits.a1.0.1",
+          "InvODT.Academy.P3D60_PQ_4000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2084_4000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/InvODT.Academy.P3D60_ST2084_4000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3DCI_48nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3DCI_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_ST2084_1000nits.a1.0.2",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_ST2048_1000nits.a1.0.1"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec2020_ST2084_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/InvODT.Academy.Rec2020_ST2084_1000nits.a1.0.2.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvRRT.a1.0.1",
+        "userName": "",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "RRT.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/rrt/InvRRT.a1.0.1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_1_1.a1.0.1",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.a1.0.1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_2_2.a1.0.1",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.a1.0.1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_7_1.a1.0.1",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM_P3D60.a1.0.1",
+        "userName": "ACES 1.0 Output - DCDM (P3 gamut clip)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM.a1.0.1",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_48nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2084_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60 ST2084 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_ST2048_1000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2084_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/ODT.Academy.P3D60_ST2084_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2084_2000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60 ST2084 (2000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_ST2048_2000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2084_2000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/ODT.Academy.P3D60_ST2084_2000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2084_4000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60 ST2084 (4000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_ST2048_4000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2084_4000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/ODT.Academy.P3D60_ST2084_4000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3DCI_48nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-DCI",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3DCI_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/p3/ODT.Academy.P3DCI_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_ST2084_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_ST2048_1000nits.a1.0.1"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec2020_ST2084_1000nits.a1.0.2",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/hdr_st2084/ODT.Academy.Rec2020_ST2084_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "RRT.a1.0.1",
+        "userName": "",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "InvRRT.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.2/transforms/ctl/rrt/RRT.a1.0.1.ctl"
+      }
+    ]
+  },
+  "v1.0.1": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 0,
+      "patchVersion": 1,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.408244Z",
+    "transforms": [
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScc.a1.0.1",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScc.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScc_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACEScc/ACEScsc.ACES_to_ACEScc.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScg.a1.0.1",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACEScg.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACEScg_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACEScg/ACEScsc.ACES_to_ACEScg.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy10i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACESproxy/ACEScsc.ACES_to_ACESproxy10i.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACES_to_ACESproxy12i.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACESproxy/ACEScsc.ACES_to_ACESproxy12i.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScc_to_ACES.a1.0.1",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScc_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScc.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACEScc/ACEScsc.ACEScc_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScg_to_ACES.a1.0.1",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACEScg_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScg.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACEScg/ACEScsc.ACEScg_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.1",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy10i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACESproxy/ACEScsc.ACESproxy10i_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.1",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ACESproxy12i_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/ACESproxy/ACEScsc.ACESproxy12i_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX10_to_ACES.a1.0.1",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX10_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/unbuild/universal/ACEScsc.ADX10_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX16_to_ACES.a1.0.1",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [
+          "ACEScsc.ADX16_to_ACES.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/unbuild/universal/ACEScsc.ADX16_to_ACES.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Adjust_Exposure.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [
+          "ACESlib.Adjust_Exposure.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Adjust_Exposure.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Lin_to_Log2_param.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Log2_to_Lin_param.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Lin_to_Log2_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Lin_to_SMPTE2048.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.ST2048_to_Lin.a1.0.1.ctl",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Lin_to_DolbyPQ.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Log2_to_Lin_param.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Lin_to_Log2_param.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Log2_to_Lin_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Lin_to_OCIOshaper_param.a1.0.1.ctl",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.OCIOshaper_to_Lin_param.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.ODT_Common.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.ODT_Common.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.RRT_Common.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.RRT_Common.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.ST2048_to_Lin.a1.0.1.ctl",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACESlib.Lin_to_SMPTE2048.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.DolbyPQ_to_Lin.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Tonescales.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Tonescales.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Transform_Common.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Transform_Common.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Unity.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Unity.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities_Color.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Utilities_Color.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities.a1.0.1",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/utilities/ACESlib.Utilities.a1.0.1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI160.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI250.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI320.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI400.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI500.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI640.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI800.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.DCDM.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.DCDM.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_48nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2048_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2048 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_PQ_1000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2048_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/InvODT.Academy.P3D60_ST2048_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2048_2000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2048 (2000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_PQ_2000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2048_2000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/InvODT.Academy.P3D60_ST2048_2000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_ST2048_4000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 ST2048 (4000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3D60_PQ_4000nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3D60_ST2048_4000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/InvODT.Academy.P3D60_ST2048_4000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3DCI_48nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.P3DCI_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_ST2048_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020 ST2048 (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec2020_ST2048_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/InvODT.Academy.Rec2020_ST2048_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [
+          "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "InvRRT.a1.0.1",
+        "userName": "",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [
+          "InvRRT.a1.0.0"
+        ],
+        "inverseTransformId": "RRT.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/rrt/InvRRT.a1.0.1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_1_1.a1.0.1",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_1_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.a1.0.1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_2_2.a1.0.1",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_2_2.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.a1.0.1.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_7_1.a1.0.1",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [
+          "LMT.Academy.ACES_0_7_1.a1.0.0"
+        ],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM_P3D60.a1.0.1",
+        "userName": "ACES 1.0 Output - DCDM (P3 gamut clip)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM_P3D60.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM.a1.0.1",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.DCDM.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_48nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3D60_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3D60_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2048_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60 ST2048 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2048_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/ODT.Academy.P3D60_ST2048_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2048_2000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60 ST2048 (2000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2048_2000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/ODT.Academy.P3D60_ST2048_2000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_ST2048_4000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-D60 ST2048 (4000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_ST2048_4000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/ODT.Academy.P3D60_ST2048_4000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3DCI_48nits.a1.0.1",
+        "userName": "ACES 1.0 Output - P3-DCI",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.P3DCI_48nits.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.P3DCI_48nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/p3/ODT.Academy.P3DCI_48nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec2020_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_ST2048_1000nits.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.2020 ST2048 (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_ST2048_1000nits.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/hdr_st2048/ODT.Academy.Rec2020_ST2048_1000nits.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [
+          "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0"
+        ],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl"
+      },
+      {
+        "transformId": "RRT.a1.0.1",
+        "userName": "",
+        "transformType": "RRT",
+        "equivalentTransformIds": [
+          "RRT.a1.0.0"
+        ],
+        "inverseTransformId": "InvRRT.a1.0.1",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0.1/transforms/ctl/rrt/RRT.a1.0.1.ctl"
+      }
+    ]
+  },
+  "v1.0": {
+    "systemVersion": {
+      "majorVersion": 1,
+      "minorVersion": 0,
+      "patchVersion": 0,
+      "packageDate": ""
+    },
+    "creationDateTime": "2025-06-09T01:22:18.450881Z",
+    "transforms": [
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScc.a1.0.0",
+        "userName": "ACES2065-1 to ACEScc",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACEScc_to_ACES.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACEScc/ACEScsc.ACES_to_ACEScc.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACEScg.a1.0.0",
+        "userName": "ACES2065-1 to ACEScg",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACEScg_to_ACES.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACEScg/ACEScsc.ACES_to_ACEScg.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.0",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACESproxy/ACEScsc.ACES_to_ACESproxy10i.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.0",
+        "userName": "ACES2065-1 to ACESproxy",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACESproxy/ACEScsc.ACES_to_ACESproxy12i.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScc_to_ACES.a1.0.0",
+        "userName": "ACEScc to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScc.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACEScc/ACEScsc.ACEScc_to_ACES.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACEScg_to_ACES.a1.0.0",
+        "userName": "ACEScg to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_ACEScg.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACEScg/ACEScsc.ACEScg_to_ACES.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy10i_to_ACES.a1.0.0",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy10i.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACESproxy/ACEScsc.ACESproxy10i_to_ACES.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ACESproxy12i_to_ACES.a1.0.0",
+        "userName": "ACESproxy to ACES2065-1",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ACEScsc.ACES_to_ACESproxy12i.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/ACESproxy/ACEScsc.ACESproxy12i_to_ACES.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX10_to_ACES.a1.0.0",
+        "userName": "ACES 1.0 Input - ADX10",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/unbuild/universal/ACEScsc.ADX10_to_ACES.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACEScsc.ADX16_to_ACES.a1.0.0",
+        "userName": "ACES 1.0 Input - ADX16",
+        "transformType": "ACEScsc",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/unbuild/universal/ACEScsc.ADX16_to_ACES.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.Adjust_Exposure.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.Adjust_Exposure.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.OCIO_shaper_lin_to_log2_param.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.OCIO_shaper_lin_to_log2_param.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.OCIO_shaper_log2_to_lin_param.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.OCIO_shaper_log2_to_lin_param.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.ODT_Common.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.ODT_Common.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.RRT_Common.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.RRT_Common.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.Tonescales.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.Tonescales.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.Transform_Common.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.Transform_Common.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.Unity.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.Unity.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities_Color.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.Utilities_Color.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ACESlib.Utilities.a1.0.0",
+        "userName": "",
+        "transformType": "ACESlib",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/utilities/ACESlib.Utilities.a1.0.0.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1000/IDT.ARRI.Alexa-v3-logC-EI1000.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1280)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1280/IDT.ARRI.Alexa-v3-logC-EI1280.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI160.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI160)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI160/IDT.ARRI.Alexa-v3-logC-EI160.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI1600)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI1600/IDT.ARRI.Alexa-v3-logC-EI1600.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI200/IDT.ARRI.Alexa-v3-logC-EI200.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2000)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2000/IDT.ARRI.Alexa-v3-logC-EI2000.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI250.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI250)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI250/IDT.ARRI.Alexa-v3-logC-EI250.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI2560)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI2560/IDT.ARRI.Alexa-v3-logC-EI2560.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI320.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI320)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI320/IDT.ARRI.Alexa-v3-logC-EI320.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI3200)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI3200/IDT.ARRI.Alexa-v3-logC-EI3200.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI400.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI400)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI400/IDT.ARRI.Alexa-v3-logC-EI400.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI500.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI500)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI500/IDT.ARRI.Alexa-v3-logC-EI500.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI640.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI640)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI640/IDT.ARRI.Alexa-v3-logC-EI640.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.ARRI.Alexa-v3-logC-EI800.a1.v1",
+        "userName": "ACES 1.0 Input - ARRI V3 LogC (EI800)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/arri/alexa/v3/EI800/IDT.ARRI.Alexa-v3-logC-EI800.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog1_SGamut_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog1",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog1_SGamut_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (daylight)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1.ctl"
+      },
+      {
+        "transformId": "IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1",
+        "userName": "ACES 1.0 Input - Sony SLog2 (tungsten)",
+        "transformType": "IDT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/idt/vendorSupplied/sony/IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.DCDM.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - DCDM",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.DCDM.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/dcdm/InvODT.Academy.DCDM.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_48nits.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D60",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D60_48nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/p3/InvODT.Academy.P3D60_48nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_PQ_1000nits.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 PQ (1000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D60_PQ_1000nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/hdr_pq/InvODT.Academy.P3D60_PQ_1000nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_PQ_2000nits.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 PQ (2000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D60_PQ_2000nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/hdr_pq/InvODT.Academy.P3D60_PQ_2000nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3D60_PQ_4000nits.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - P3-D60 PQ (4000 nits)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3D60_PQ_4000nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/hdr_pq/InvODT.Academy.P3D60_PQ_4000nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.P3DCI_48nits.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - P3-DCI",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.P3DCI_48nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_48nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.2020",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.709",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec709_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - Rec.709 (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Inverse Output - sRGB (D60 sim.)",
+        "transformType": "InvODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "InvRRT.a1.0.0",
+        "userName": "",
+        "transformType": "InvRRT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "RRT.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/rrt/InvRRT.a1.0.0.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_1_1.a1.0.0",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.1 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/lmt/LMT.Academy.ACES_0_1_1.a1.0.0.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_2_2.a1.0.0",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.2 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/lmt/LMT.Academy.ACES_0_2_2.a1.0.0.ctl"
+      },
+      {
+        "transformId": "LMT.Academy.ACES_0_7_1.a1.0.0",
+        "userName": "ACES 1.0 Look - ACES 1.0 to 0.7 emulation",
+        "transformType": "LMT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/lmt/LMT.Academy.ACES_0_7_1.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM_P3D60.a1.0.0",
+        "userName": "ACES 1.0 Output - DCDM (P3 gamut clip)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/dcdm/ODT.Academy.DCDM_P3D60.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.DCDM.a1.0.0",
+        "userName": "ACES 1.0 Output - DCDM",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.DCDM.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/dcdm/ODT.Academy.DCDM.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_48nits.a1.0.0",
+        "userName": "ACES 1.0 Output - P3-D60",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_48nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/p3/ODT.Academy.P3D60_48nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_PQ_1000nits.a1.0.0",
+        "userName": "ACES 1.0 Output - P3-D60 PQ (1000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_PQ_1000nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/hdr_pq/ODT.Academy.P3D60_PQ_1000nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_PQ_2000nits.a1.0.0",
+        "userName": "ACES 1.0 Output - P3-D60 PQ (2000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_PQ_2000nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/hdr_pq/ODT.Academy.P3D60_PQ_2000nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3D60_PQ_4000nits.a1.0.0",
+        "userName": "ACES 1.0 Output - P3-D60 PQ (4000 nits)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3D60_PQ_4000nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/hdr_pq/ODT.Academy.P3D60_PQ_4000nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.P3DCI_48nits.a1.0.0",
+        "userName": "ACES 1.0 Output - P3-DCI",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.P3DCI_48nits.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/p3/ODT.Academy.P3DCI_48nits.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec2020_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Output - Rec.2020",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec2020_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Output - Rec.709",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec709_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Output - Rec.709 (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0",
+        "userName": "ACES 1.0 Output - sRGB (D60 sim.)",
+        "transformType": "ODT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.0.ctl"
+      },
+      {
+        "transformId": "RRT.a1.0.0",
+        "userName": "",
+        "transformType": "RRT",
+        "equivalentTransformIds": [],
+        "inverseTransformId": "InvRRT.a1.0.0",
+        "file": "https://raw.githubusercontent.com/ampas/aces-core/refs/tags/v1.0/transforms/ctl/rrt/RRT.a1.0.0.ctl"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds a JSON manifest organized by version tag.

At creation, the tags included are ["v2.0.0+2025.04.04", "v1.3.1", "v1.3", "v1.2", "v1.1", "v1.0.3", "v1.0.2", "v1.0.1", "v.1.0"]

Prior to v2, all the permanent file urls are linked to aces-core (previously aces-dev). After 2.0, the transforms were broken into sub-repositories and the parent repo points to a specific commit in each of the sub-repositories. The script used to parse the v2 transforms pulls the SHA ID for each of  

The general structure is:
``` json
{
  "v2.0.0+2025.04.04": {
    "systemVersion": {
      "majorVersion": 2,
      "minorVersion": 0,
      "patchVersion": 0,
      "packageDate": "2025.04.04"
    },
    "creationDateTime": "2025-06-09T01:22:18.062882Z",
    "transforms": [
      {
        "transformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACES_to_ACEScc.a2.v1",
        "userName": "ACES2065-1 to ACEScc",
        "transformType": "CSC",
        "equivalentTransformIds": [
          "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3",
          "ACEScsc.ACES_to_ACEScc.a1.0.3",
          "ACEScsc.ACEScc_to_ACES.a1.0.1",
          "ACEScsc.ACEScc_to_ACES.a1.0.0"
        ],
        "inverseTransformId": "urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScc_to_ACES.a2.v1",
        "file": "https://raw.githubusercontent.com/ampas/aces-input-and-colorspaces/cc60becf11534f2a40df00a281f47e95412d0599/ACEScc/CSC.Academy.ACES_to_ACEScc.ctl"
      }, ... 
    ]
  },
  "v1.3.1": { ...
  },
  "v1.3": { ...
  }, ...
}

```
